### PR TITLE
fix : 레이아웃간격 수정

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -46,7 +46,7 @@
     .sidebarHeader{
         width: 210px;
         height: 54px;
-        margin-top: 62px;
+        padding-top: 62px;
 
     }
     
@@ -83,7 +83,7 @@
     .itemText{
         width: 77.51px;
         height: 18px;
-        margin-top: 20px;
+        margin-top: 18px;
         margin-left: 20px;
         font-family: "Noto Sans KR";
         font: 350 16px light;


### PR DESCRIPTION
itemText -> margin-top 20px에서 18px로 변경
 - item padding-top 2px로 인하여 글자가 내려가 보여서 조절
sidebarHeader -> margin-top을 padding-top으로 변경
 - boardUpper의 border-bottom 라인과 위치 동일하게 조절